### PR TITLE
Replace validation logic with graph traversal

### DIFF
--- a/saml_reader/cli.py
+++ b/saml_reader/cli.py
@@ -8,7 +8,7 @@ import json
 import argparse
 
 from saml_reader.text_reader import TextReader
-from saml_reader.mongo import MongoFederationConfig, MongoVerifier
+from saml_reader.validation.mongo import MongoFederationConfig, MongoVerifier
 from saml_reader.saml.parser import DataTypeInvalid
 from saml_reader import __version__
 

--- a/saml_reader/mongo.py
+++ b/saml_reader/mongo.py
@@ -2,7 +2,7 @@
 These classes handle all data validation specific to MongoDB Cloud
 """
 import re
-from saml_reader.validation import TestDefinition, TestSuite, FAIL
+from saml_reader.validation import TestDefinition, TestSuite, TEST_FAIL
 
 """Regular expression to match (most) valid e-mail addresses"""
 EMAIL_REGEX_MATCH = r"\b(?i)([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b"
@@ -212,7 +212,7 @@ class MongoVerifier:
         results = test_suite.get_results()
         messages_to_add = [
             failure_messages[test] for test, result in results.items()
-            if result == FAIL and test in failure_messages
+            if result == TEST_FAIL and test in failure_messages
         ]
         self._errors.extend(messages_to_add)
 

--- a/saml_reader/saml/parser.py
+++ b/saml_reader/saml/parser.py
@@ -330,9 +330,9 @@ class StandardSamlParser(BaseSamlParser):
         Retrieves the identity provider's claim attributes.
 
         Returns:
-            (dict) Claim attribute values keyed by attribute name, None if no attributes were found
+            (dict) Claim attribute values keyed by attribute name, empty dict if no attributes were found
         """
-        return self._saml_values.get('attributes')
+        return self._saml_values.get('attributes') or dict()
 
     def is_assertion_found(self):
         """
@@ -569,9 +569,9 @@ class RegexSamlParser(BaseSamlParser):
         Retrieves the identity provider's claim attributes.
 
         Returns:
-            (dict) Claim attribute values keyed by attribute name, None if no values found
+            (dict) Claim attribute values keyed by attribute name, empty dict if no values found
         """
-        return self._saml_values.get('attributes')
+        return self._saml_values.get('attributes') or dict()
 
     def is_assertion_found(self):
         """

--- a/saml_reader/validation.py
+++ b/saml_reader/validation.py
@@ -1,9 +1,11 @@
 """
-Validation classes
+These classes implement a graph-based approach to running a battery of validation tests
+where one test can depend on the pass/fail state of another test.
 """
 
 import networkx as nx
 
+# Test completion states
 TEST_PASS = 1
 TEST_FAIL = 0
 TEST_NOT_RUN = -1
@@ -43,7 +45,7 @@ class TestDefinition:
                 raise ValueError(f"Missing context values for test: {missing_context}")
         result = self._func({x: context[x] for x in self.required_context})
         if isinstance(result, tuple):
-            self.status = result[0]
+            self.status = bool(result[0])
             self._result_metadata = result[1:]
         else:
             self.status = int(bool(result))

--- a/saml_reader/validation.py
+++ b/saml_reader/validation.py
@@ -121,16 +121,15 @@ class TestSuite:
             self._results[test] = test.status
 
     def _get_next_test(self):
-        tests_remain = True
-        while tests_remain:
-            tests_to_run = [
-                test for test, n_unmet_dependencies in self._test_graph.in_degree
-                if n_unmet_dependencies == 0 and test.status == TEST_NOT_RUN
-            ]
-            if not tests_to_run:
-                tests_remain = False
-            else:
-                yield from tests_to_run
+        def __yield_tests_rec(graph):
+            tests = [test for test, n_unmet_dependencies in graph.in_degree
+                     if n_unmet_dependencies == 0 and test.status == TEST_NOT_RUN]
+            if not tests:
+                return
+            yield from tests
+            yield from __yield_tests_rec(graph)
+
+        yield from __yield_tests_rec(self._test_graph)
 
     def has_run(self):
         return self._has_run

--- a/saml_reader/validation.py
+++ b/saml_reader/validation.py
@@ -1,0 +1,139 @@
+"""
+Validation classes
+"""
+
+import networkx as nx
+
+PASS = 1
+FAIL = 0
+NOT_RUN = -1
+
+
+class TestDefinition:
+    def __init__(self, title, test_function, dependencies=None, required_context=None):
+        self.status = NOT_RUN
+        self.dependencies = set(dependencies) if dependencies else set()
+        self.title = title or ""
+        self.required_context = set(required_context) if required_context else set()
+        if not callable(test_function):
+            raise ValueError("test_function not a callable object")
+        self._func = test_function
+        self._result_metadata = None
+
+    def add_dependency(self, dependency):
+        self.dependencies.add(dependency)
+
+    def remove_dependency(self, dependency):
+        if dependency in self.dependencies:
+            self.dependencies.remove(dependency)
+
+    def add_required_context_value(self, context):
+        self.required_context.add(context)
+
+    def remove_required_context_value(self, context):
+        if context in self.required_context:
+            self.required_context.remove(context)
+
+    def run(self, context=None):
+        if self.required_context:
+            if not context:
+                raise ValueError("No context provided when context values required")
+            if any(x not in context for x in self.required_context):
+                missing_context = self.required_context - self.required_context.intersection(set(context.keys()))
+                raise ValueError(f"Missing context values for test: {missing_context}")
+        result = self._func({x: context[x] for x in self.required_context})
+        if isinstance(result, tuple):
+            self.status = result[0]
+            self._result_metadata = result[1:]
+        else:
+            self.status = int(bool(result))
+        return self.status
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.title == other
+        elif isinstance(other, TestDefinition):
+            return self.title == other.title
+        raise NotImplemented
+
+    def __hash__(self):
+        # This is bad hash right now
+        return hash(self.title)
+
+
+class TestSuite:
+    def __init__(self):
+        self._tests = set()
+        self._context = dict()
+        self._test_graph = nx.DiGraph()
+        self._results = None
+        self._has_run = False
+
+    def context_satisfies_requirements(self):
+        return all(context_value in self._context
+                   for test in self._tests
+                   for context_value in test.required_context)
+
+    def all_dependent_test_in_suite(self):
+        return all(dependency in self._tests
+                   for test in self._tests
+                   for dependency in test.dependencies)
+
+    def add_test(self, test: TestDefinition, replace=True):
+        if not replace and test in self._tests:
+            raise ValueError(f"Suite already contains test '{test.title}'")
+        self._tests.add(test)
+
+    def remove_test(self, test):
+        if test in self._tests:
+            self._tests.remove(test)
+
+    def set_context(self, context):
+        self._context = context
+
+    def run(self):
+        if not self.context_satisfies_requirements():
+            raise ValueError("Context is missing required values for tests")
+        if not self.all_dependent_test_in_suite():
+            raise ValueError("Dependency test missing")
+
+        self._build_graph()
+        self._run_suite()
+        self._has_run = True
+
+    def _build_graph(self):
+        self._test_graph.add_nodes_from(self._tests)
+        test_lookup = {test.title: test for test in self._tests}
+        for test in self._tests:
+            for dependency in test.dependencies:
+                self._test_graph.add_edge(test_lookup[dependency], test)
+
+    def _run_suite(self):
+        tests_to_run = self._get_next_set_of_tests()
+        count = 1
+        while tests_to_run:
+            # print(f"Round {count}")
+            for test in tests_to_run:
+                # print(f"Running test {test.title}")
+                if test.run(self._context):
+                    self._test_graph.remove_node(test)
+            tests_to_run = self._get_next_set_of_tests()
+            count += 1
+
+        self._results = dict()
+        for test in self._tests:
+            # print(f"Test: {test.title}, Result: {test.status}")
+            self._results[test] = test.status
+
+    def _get_next_set_of_tests(self):
+        return [test for test, n_unmet_dependencies in self._test_graph.in_degree
+                if n_unmet_dependencies == 0 and test.status == NOT_RUN]
+
+    def has_run(self):
+        return self._has_run
+
+    def get_results(self):
+        if self.has_run():
+            return {k.title: v for k, v in self._results.items()}
+        raise ValueError("Test suite not run!")
+

--- a/saml_reader/validation.py
+++ b/saml_reader/validation.py
@@ -5,16 +5,40 @@ where one test can depend on the pass/fail state of another test.
 
 import networkx as nx
 
-# Test completion states
+"""Test completion states"""
 TEST_PASS = 1
 TEST_FAIL = 0
 TEST_NOT_RUN = -1
 
 
 class TestDefinition:
+    """
+    Defines a single validation test to be run, ideally run as part of a suite.
+    """
     def __init__(self, title, test_function, dependencies=None, required_context=None):
+        """
+        Construct a validation test.
+
+        Args:
+            title (basestring): The name of the test. This must be unique across tests
+                that are a part of a suite.
+            test_function (callable): A function which must take one argument (a dict) that
+                contains context data required for running the test. It must return at least one
+                value, which will be cast as a boolean to determine pass/fail. If multiple values
+                are returned, the first value will be used to determine the test result, and the
+                rest will be stored and can be retrieved with `get_result_metadata()`.
+            dependencies (`iterable` of `basestring`, `TestDefinition` or `tuple`): an iterable
+                containing test titles (as strings), test definitions (as `TestDefinition`), or
+                two-member tuples, where the first element is a title or test definition and the
+                second element is the required outcome of that test (TEST_PASS or TEST_FAIL).
+                For titles and definitions, the default required outcome is TEST_PASS. Default: None.
+            required_context (`iterable` of `basestring`): an iterable containing names of keys expected
+                by the test in the context data. Default: None.
+        """
         self.status = TEST_NOT_RUN
         self.dependencies = dict()
+
+        # Assign required results for dependencies
         for dependency in dependencies or []:
             if isinstance(dependency, (str, TestDefinition)):
                 self.dependencies[dependency] = TEST_PASS
@@ -25,43 +49,113 @@ class TestDefinition:
                 if required_result not in (TEST_PASS, TEST_FAIL):
                     raise ValueError("Dependency result must be TEST_PASS or TEST_FAIL")
                 self.dependencies[test] = required_result
+
         self.title = title or ""
         self.required_context = set(required_context) if required_context else set()
+
         if not callable(test_function):
             raise ValueError("test_function not a callable object")
         self._func = test_function
+
         self._result_metadata = None
 
     def add_dependency(self, dependency, required_result=TEST_PASS):
+        """
+        Add single test dependency and the required result.
+
+        Args:
+            dependency (`basestring` or `TestDefinition`): Test object or test
+                name that this test depends on
+            required_result (int): Whether the dependent test should pass (1, TEST_PASS)
+                or fail (0, TEST_FAIL) to meet the dependency requirement. Default: TEST_PASS
+        """
         self.dependencies[dependency] = required_result
 
     def remove_dependency(self, dependency):
+        """
+        Remove single test dependency, if it exists as a dependency.
+
+        Args:
+            dependency (`basestring` or `TestDefinition`): Test object or test
+                name to remove.
+        """
         if dependency in self.dependencies:
             self.dependencies.pop(dependency)
 
     def add_required_context_value(self, context):
+        """
+        Add single context variable required for the test.
+
+        Args:
+            context (basestring): Name of variable to include in
+                context data passed to function.
+        """
         self.required_context.add(context)
 
     def remove_required_context_value(self, context):
+        """
+        Remove single required context variable, if it exists.
+
+        Args:
+            context (basestring): Name of context variable to remove
+        """
         if context in self.required_context:
             self.required_context.remove(context)
 
     def run(self, context=None):
+        """
+        Run the test function with the provided context variables.
+
+        Args:
+            context (dict): Context values required for the test.
+
+        Returns:
+            (bool) result of the test
+
+        Raises:
+            (ValueError) if provided context does not match expected context
+        """
+        # Check provided context to ensure it has all required values
         if self.required_context:
             if not context:
                 raise ValueError("No context provided when context values required")
             if any(x not in context for x in self.required_context):
                 missing_context = self.required_context - self.required_context.intersection(set(context.keys()))
                 raise ValueError(f"Missing context values for test: {missing_context}")
+
+        # Run the test with required context
         result = self._func({x: context[x] for x in self.required_context})
+
+        # Assess result
         if isinstance(result, tuple):
-            self.status = bool(result[0])
+            self.status = int(bool(result[0]))
             self._result_metadata = result[1:]
         else:
             self.status = int(bool(result))
         return self.status
 
+    def get_result_metadata(self):
+        """
+        Retrieves the metadata returned by the completed test.
+
+        Returns:
+            (tuple) stored metadata returned by test. None if no metadata returned.
+        """
+        return self._result_metadata
+
     def __eq__(self, other):
+        """
+        Equality with strings and other `TestDefinition` objects, by comparing title.
+
+        Args:
+            other (`basestring` or `TestDefinition`): value to compare
+
+        Returns:
+            (bool) True if matching titles, False otherwise
+
+        Raises:
+            (NotImplemented) if type of `other` is not one of types listed
+        """
         if isinstance(other, str):
             return self.title == other
         elif isinstance(other, TestDefinition):
@@ -79,7 +173,19 @@ class TestDefinition:
 
 
 class _FailedTest(TestDefinition):
+    """
+    Internal class to block advancement of graph traversal when a test depends on
+    the failure of another test, and that test passes. Fails automatically when run
+    to block advancement.
+    """
     def __init__(self, test_to_monitor):
+        """
+        Create a blocker node for required test failures.
+
+        Args:
+            test_to_monitor (`basestring` or `TestDefinition`): test to monitor
+                (value is rather inconsequential to operation)
+        """
         super().__init__(
             f"Blocker for tests depending on failure of: {test_to_monitor}",
             lambda x: TEST_FAIL,
@@ -88,7 +194,13 @@ class _FailedTest(TestDefinition):
 
 
 class TestSuite:
+    """
+    A collection of tests to run as a group. Manages test dependencies.
+    """
     def __init__(self):
+        """
+        Construct the suite.
+        """
         self._tests = set()
         self._context = dict()
         self._test_graph = nx.DiGraph()
@@ -96,28 +208,73 @@ class TestSuite:
         self._has_run = False
 
     def context_satisfies_requirements(self):
+        """
+        Checks if provided context satisfies the requirements of all tests
+        in the suite.
+
+        Returns:
+            (bool) True if all context requirements are satisfied, and False otherwise
+        """
         return all(context_value in self._context
                    for test in self._tests
                    for context_value in test.required_context)
 
     def all_dependent_test_in_suite(self):
+        """
+        Checks if every test in the suite has its dependent tests in the suite.
+
+        Returns:
+            (bool) True if all dependency tests are in the suite, and False otherwise
+        """
         return all(dependency in self._tests
                    for test in self._tests
                    for dependency in test.dependencies.keys())
 
-    def add_test(self, test: TestDefinition, replace=True):
+    def add_test(self, test, replace=True):
+        """
+        Add a test to the suite.
+
+        Args:
+            test (TestDefinition): Test object to add to the suite
+            replace (bool): if True, replace the test if it exists. False will
+                raise a ValueError if a test with the same name is in the suite.
+
+        Raises:
+            (ValueError) if test with same title exists in the suite and `replace=False`
+
+        """
         if not replace and test in self._tests:
             raise ValueError(f"Suite already contains test '{test.title}'")
         self._tests.add(test)
 
     def remove_test(self, test):
+        """
+        Remove test from suite if it exists.
+
+        Args:
+            test (`basestring` or `TestDefinition`): title or test object to
+                remove from suite
+        """
         if test in self._tests:
             self._tests.remove(test)
 
     def set_context(self, context):
+        """
+        Set the context values for the test suite that will be passed to each
+        test.
+
+        Args:
+            context (dict): context values, keyed by context variable names
+        """
         self._context = context
 
     def run(self):
+        """
+        Run the test suite with the given context.
+
+        Raises:
+            (ValueError) if context or dependencies are not satisfied
+        """
         if not self.context_satisfies_requirements():
             raise ValueError("Context is missing required values for tests")
         if not self.all_dependent_test_in_suite():
@@ -128,27 +285,43 @@ class TestSuite:
         self._has_run = True
 
     def _build_graph(self):
+        """
+        Builds directional graph of tests for traversal.
+        Nodes are tests and edges are dependencies.
+        """
+
+        # Load all tests as nodes
         for test in self._tests:
             node_name = "PASS_" + test.title
             self._test_graph.add_node(node_name, test_object=test)
 
+        # Create edges based on dependencies
         for test in self._tests:
             for dependency, required_result in test.dependencies.items():
                 child_node_name = "PASS_" + test.title
                 if required_result == TEST_PASS:
                     parent_node_name = "PASS_" + str(dependency)
                 elif required_result == TEST_FAIL:
+                    # If a test requires that another test fail,
+                    # create an interim node to block traversal if the
+                    # dependent test passes. This node will be removed if
+                    # the dependent test passes.
                     parent_node_name = "FAIL_" + str(dependency)
                     self._test_graph.add_node(
                         parent_node_name,
                         test_object=_FailedTest(dependency)
                     )
+                    # Draw edge from dependent test to blocking node
                     self._test_graph.add_edge("PASS_" + str(dependency), parent_node_name)
                 else:
                     raise ValueError("Invalid required test result!")
+                # Draw edge from dependent test (or blocking node) to current test
                 self._test_graph.add_edge(parent_node_name, child_node_name)
 
     def _run_suite(self):
+        """
+        Run tests and record results.
+        """
         for test in self._get_next_test():
             # print(f"Running test {test.title}")
             test.run(self._context)
@@ -157,31 +330,62 @@ class TestSuite:
         self._results = {test: test.status for test in self._tests}
 
     def _get_next_test(self):
+        """
+        Traverses graph recursively and generates tests to run. As tests pass,
+        the nodes are removed from the graph.
+
+        Yields:
+            (TestDefinition) test to run
+        """
         def __yield_tests_rec(graph):
             queue_for_removal = set()
+            # Traverse all nodes by all inbound edges in the current view of the graph
             for test_name, n_unmet_dependencies in graph.in_degree:
                 test_object = graph.nodes[test_name]['test_object']
                 if n_unmet_dependencies == 0 and test_object.status == TEST_NOT_RUN:
+                    # If there are no unmet dependencies (presence of no inbound edges)
+                    # and the test hasn't been run, then send it up to be run.
                     yield test_object
+
                     if test_object.status == TEST_PASS:
+                        # If test passes, queue node for removal on next pass
                         queue_for_removal.add(test_name)
                     elif test_object.status == TEST_FAIL:
+                        # If test fails, queue the related blocker node to be removed on next pass (if exists)
                         queue_for_removal.add("FAIL_" + str(test_object))
                     else:
                         raise ValueError("Invalid test result")
+
+            # Exit criterion: if no tests ran, process is finished
             if not queue_for_removal:
                 return
+            # Delete queued nodes from graph
             graph.remove_nodes_from(queue_for_removal)
+            # Clear queue to save memory
             queue_for_removal.clear()
+            # Recurse on new view of graph
+            # TODO: consider not using recursion as it could get hit recursion depth limit if many
+            #       rounds of testing have to be done
             yield from __yield_tests_rec(graph)
-
+        # Begin recursion
         yield from __yield_tests_rec(self._test_graph)
 
     def has_run(self):
+        """
+        Returns if suite has been run or not.
+
+        Returns:
+            (bool) True if suite has run, False otherwise
+        """
         return self._has_run
 
     def get_results(self):
+        """
+        Outputs the results of the tests.
+
+        Returns:
+            (dict) test results, keyed by test title. 0 = TEST_FAIL, 1 = TEST_PASS, -1 = TEST_NOT_RUN
+        """
         if self.has_run():
             return {k.title: v for k, v in self._results.items()}
         raise ValueError("Test suite not run!")
-

--- a/saml_reader/validation.py
+++ b/saml_reader/validation.py
@@ -305,7 +305,7 @@ class TestSuite:
                     # If a test requires that another test fail,
                     # create an interim node to block traversal if the
                     # dependent test passes. This node will be removed if
-                    # the dependent test passes.
+                    # the dependent test fails to allow child tests to run.
                     parent_node_name = "FAIL_" + str(dependency)
                     self._test_graph.add_node(
                         parent_node_name,

--- a/saml_reader/validation.py
+++ b/saml_reader/validation.py
@@ -150,13 +150,11 @@ class TestSuite:
 
     def _run_suite(self):
         for test in self._get_next_test():
-            print(f"Running test {test.title}")
+            # print(f"Running test {test.title}")
             test.run(self._context)
-            print(f"Test: {test.title}, Result: {test.status}")
+            # print(f"Test: {test.title}, Result: {test.status}")
 
-        self._results = dict()
-        for test in self._tests:
-            self._results[test] = test.status
+        self._results = {test: test.status for test in self._tests}
 
     def _get_next_test(self):
         def __yield_tests_rec(graph):

--- a/saml_reader/validation/graph_suite.py
+++ b/saml_reader/validation/graph_suite.py
@@ -203,7 +203,7 @@ class TestSuite:
         """
         self._tests = set()
         self._context = dict()
-        self._test_graph = nx.DiGraph()
+        self._test_graph = None
         self._results = None
         self._has_run = False
 
@@ -299,6 +299,8 @@ class TestSuite:
         Builds directional graph of tests for traversal.
         Nodes are tests and edges are dependencies.
         """
+
+        self._test_graph = nx.DiGraph()
 
         # Load all tests as nodes
         for test in self._tests:

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -1044,8 +1044,26 @@ class ValidationReport:
                "the value entered for comparison." + \
                f"\nSAML value: {self._saml.get_attributes().get(attribute_name)}" + \
                f"\nSpecified comparison value: {self._comparison_values.get_value(attribute_name)}" + \
-               "\nGenerally, this means that the identity provider configuration needs\n" + \
+               "\n\nGenerally, this means that the identity provider configuration needs\n" + \
                "to be reconfigured to match the expected values"
+
+    @staticmethod
+    def _print_a_list(template_string, list_contents):
+        """
+        Outputs a list of items based on a template. For example:
+        if `template_string` is `"\n- {}"` and `list_contents` contains
+        `['a', 'b', 'c']`, the outputted string will be `\n- a\n- b\n- c`.
+
+        Args:
+            template_string (basestring): template to repeat. Must have exactly one `{}` to
+                be replaced
+            list_contents (iterable): values to replace in template string
+
+        Returns:
+            (basestring) string that represents item list
+        """
+        full_string = template_string * len(list_contents)
+        return full_string.format(*list_contents)
 
     def _compile_messages(self):
         """
@@ -1076,8 +1094,7 @@ class ValidationReport:
                 f"The Name ID format is not an acceptable format.\n" +
                 f"SAML value: {self._saml.get_subject_name_id_format()}\n" +
                 f"Acceptable formats:" +
-                ("\n - {}" * len(MongoTestSuite.VALID_NAME_ID_FORMATS)).format(
-                    *MongoTestSuite.VALID_NAME_ID_FORMATS),
+                self._print_a_list("\n - {}", MongoTestSuite.VALID_NAME_ID_FORMATS),
 
             # Claim attribute tests
             'exists_first_name': self._get_claim_attribute_exist('firstName'),
@@ -1094,11 +1111,9 @@ class ValidationReport:
             'compare_domain_email':
                 "The 'email' attribute does not contain one of the federated domains specified:\n" +
                 f"SAML 'email' attribute value: {self._saml.get_subject_name_id()}\n" +
-                f"Specified valid domains:\n" +
-                ("- {}\n" * len(self._comparison_values.get_value('domains', []))).format(
-                    *self._comparison_values.get_value('domains', [])
-                ) +
-                "If the 'email' attribute does not contain a verified domain name, it may be because\n" +
+                f"Specified valid domains:" +
+                self._print_a_list("\n - {}", self._comparison_values.get_value('domains', [])) +
+                "\n\nIf the 'email' attribute does not contain a verified domain name, it may be because\n" +
                 "the source Active Directory field does not contain the user's e-mail address.\n" +
                 "The source field may contain an internal username or other value instead.\n" +
                 "This is not necessarily an error, but may indicate there is a misconfiguration.\n" +
@@ -1109,20 +1124,16 @@ class ValidationReport:
                 "The specified comparison e-mail value does not contain\n" +
                 "one of the federated domains specified:\n" +
                 f"Specified e-mail value: {self._comparison_values.get_value('email')}\n" +
-                f"Specified valid domains:\n" +
-                ("- {}\n" * len(self._comparison_values.get_value('domains', []))).format(
-                    *self._comparison_values.get_value('domains', [])
-                ) +
-                "If the e-mail specified is the user's MongoDB username, then the Atlas\n" +
+                f"Specified valid domains:" +
+                self._print_a_list("\n - {}", self._comparison_values.get_value('domains', [])) +
+                "\n\nIf the e-mail specified is the user's MongoDB username, then the Atlas\n" +
                 "identity provider configuration likely has the incorrect domain(s) verified.",
             'compare_domain_name_id':
                 "The Name ID does not contain one of the federated domains specified:\n" +
                 f"Name ID value: {self._saml.get_subject_name_id()}\n" +
-                f"Specified valid domains:\n" +
-                ("- {}\n" * len(self._comparison_values.get_value('domains', []))).format(
-                    *self._comparison_values.get_value('domains', [])
-                ) +
-                "If the Name ID does not contain a verified domain name, it may be because\n" +
+                f"Specified valid domains:" +
+                self._print_a_list("\n - {}", self._comparison_values.get_value('domains', [])) +
+                "\n\nIf the Name ID does not contain a verified domain name, it may be because\n" +
                 "the source Active Directory field does not contain the user's e-mail address.\n" +
                 "The source field may contain an internal username or other value instead.",
 
@@ -1131,7 +1142,7 @@ class ValidationReport:
                 "The Name ID does not match the provided e-mail value:\n" +
                 f"Name ID value: {self._saml.get_subject_name_id()}\n" +
                 f"Specified email value: {self._comparison_values.get_value('email')}" +
-                "\nThis is not necessarily an error, but may indicate there is a misconfiguration.\n" +
+                "\n\nThis is not necessarily an error, but may indicate there is a misconfiguration.\n" +
                 "The value in Name ID will be the user's login username and the value in the\n" +
                 "email attribute will be the address where the user receives email messages.",
             'match_name_id_email_in_saml':
@@ -1151,7 +1162,7 @@ class ValidationReport:
                 "The Issuer URI in the SAML response does not match the specified comparison value:\n" +
                 f"SAML value: {self._saml.get_issuer_uri()}\n" +
                 f"Specified comparison value: {self._comparison_values.get_value('issuer')}" +
-                "\nGenerally, this means that the Atlas configuration needs " +
+                "\n\nGenerally, this means that the Atlas configuration needs " +
                 "to be set to match the SAML value",
 
             # Audience URL tests
@@ -1165,7 +1176,7 @@ class ValidationReport:
                 "The Audience URL in the SAML response does not match the specified comparison value:\n" +
                 f"SAML value: {self._saml.get_audience_url()}\n" +
                 f"Specified comparison value: {self._comparison_values.get_value('audience')}" +
-                "\nGenerally, this means that the Atlas configuration needs " +
+                "\n\nGenerally, this means that the Atlas configuration needs " +
                 "to be set to match the SAML value",
 
             # ACS URL tests
@@ -1180,7 +1191,7 @@ class ValidationReport:
                 "specified comparison value:\n" +
                 f"SAML value: {self._saml.get_assertion_consumer_service_url()}\n" +
                 f"Specified comparison value: {self._comparison_values.get_value('acs')}" +
-                "\nThis means that the identity provider configuration needs\n" +
+                "\n\nThis means that the identity provider configuration needs\n" +
                 "to be reconfigured to match the expected value",
 
             # Encryption algorithm tests
@@ -1196,7 +1207,7 @@ class ValidationReport:
                 f"SAML value: {self._saml.get_encryption_algorithm()}\n" +
                 f"Specified comparison value: " +
                 f"{self._comparison_values.get_value('encryption')}" +
-                "\nGenerally, this means that the Atlas configuration needs " +
+                "\n\nGenerally, this means that the Atlas configuration needs " +
                 "to be set to match the SAML value"
         }
 

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -248,7 +248,7 @@ class MongoFederationConfig:
 
         Args:
             value_name (basestring): name of comparison value keyword
-            default: the value returned if the comparison value is not populated. Default: None
+            default (object, optional): the value returned if the comparison value is not populated. Default: None
 
         Returns:
             (`basestring` or `None`) comparison value, `None` if name does not exist
@@ -332,7 +332,7 @@ class MongoTestSuite(TestSuite):
 
         Args:
             saml (BaseSamlParser): parsed SAML data
-            comparison_values (MongoFederationConfig): comparison values to
+            comparison_values (MongoFederationConfig, optional): comparison values to
                 compare with data in SAML response. Default: None (no comparison
                 tests will be performed)
         """
@@ -1002,7 +1002,7 @@ class ValidationReport:
             comparison_values (MongoFederationConfig): comparison data
         """
         self._saml = saml
-        self._comparison_values: MongoFederationConfig = comparison_values
+        self._comparison_values = comparison_values
         self._messages = None
         self._compile_messages()
 

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -2,7 +2,7 @@
 These classes handle all data validation specific to MongoDB Cloud
 """
 import re
-from saml_reader.validation.validation import TestDefinition, TestSuite, TEST_FAIL
+from saml_reader.validation.graph_suite import TestDefinition, TestSuite, TEST_FAIL
 
 """Regular expression to match (most) valid e-mail addresses"""
 EMAIL_REGEX_MATCH = r"\b(?i)([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b"

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -32,7 +32,7 @@ class MongoVerifier:
         parameters.
 
         Args:
-            saml (SamlParser): SAML response
+            saml (BaseSamlParser): SAML response
             cert (Certificate, optional): Certificate information
             comparison_values (MongoFederationConfig, optional): user-entered values to check
                 against SAML data

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -547,7 +547,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if they match, False otherwise
         """
-        return context.get('saml').get_issuer_uri() == context.get_value('issuer')
+        return context.get('saml').get_issuer_uri() == context.get('comparison_values').get_value('issuer')
 
     @staticmethod
     def verify_issuer_pattern(context):

--- a/saml_reader/validation/validation.py
+++ b/saml_reader/validation/validation.py
@@ -258,6 +258,16 @@ class TestSuite:
         if test in self._tests:
             self._tests.remove(test)
 
+    def get_context(self):
+        """
+        Get the context values for the test suite that will be passed to each
+        test.
+
+        Returns:
+            (dict) context values, keyed by context variable names. Empty dict if none.
+        """
+        return self._context or dict()
+
     def set_context(self, context):
         """
         Set the context values for the test suite that will be passed to each

--- a/saml_reader/validation/validation.py
+++ b/saml_reader/validation/validation.py
@@ -27,12 +27,12 @@ class TestDefinition:
                 value, which will be cast as a boolean to determine pass/fail. If multiple values
                 are returned, the first value will be used to determine the test result, and the
                 rest will be stored and can be retrieved with `get_result_metadata()`.
-            dependencies (`iterable` of `basestring`, `TestDefinition` or `tuple`): an iterable
+            dependencies (`iterable` of `basestring`, `TestDefinition` or `tuple`, optional): an iterable
                 containing test titles (as strings), test definitions (as `TestDefinition`), or
                 two-member tuples, where the first element is a title or test definition and the
                 second element is the required outcome of that test (TEST_PASS or TEST_FAIL).
                 For titles and definitions, the default required outcome is TEST_PASS. Default: None.
-            required_context (`iterable` of `basestring`): an iterable containing names of keys expected
+            required_context (`iterable` of `basestring`, optional): an iterable containing names of keys expected
                 by the test in the context data. Default: None.
         """
         self.status = TEST_NOT_RUN
@@ -66,7 +66,7 @@ class TestDefinition:
         Args:
             dependency (`basestring` or `TestDefinition`): Test object or test
                 name that this test depends on
-            required_result (int): Whether the dependent test should pass (1, TEST_PASS)
+            required_result (int, optional): Whether the dependent test should pass (1, TEST_PASS)
                 or fail (0, TEST_FAIL) to meet the dependency requirement. Default: TEST_PASS
         """
         self.dependencies[dependency] = required_result
@@ -107,7 +107,7 @@ class TestDefinition:
         Run the test function with the provided context variables.
 
         Args:
-            context (dict): Context values required for the test.
+            context (dict, optional): Context values required for the test.
 
         Returns:
             (bool) result of the test
@@ -236,7 +236,7 @@ class TestSuite:
 
         Args:
             test (TestDefinition): Test object to add to the suite
-            replace (bool): if True, replace the test if it exists. False will
+            replace (bool, optional): if True, replace the test if it exists. False will
                 raise a ValueError if a test with the same name is in the suite.
 
         Raises:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
             'pyperclip',
             'haralyzer',
             'python3-saml',
-            'cryptography'
+            'cryptography',
+            'networkx'
       ]
 )


### PR DESCRIPTION
Because it was more fun than writing tests, I decided to implement SAML validation as a graph traversal (issue #15)

While it didn't make the code "easier to read," it did compartmentalize the code more and make it more extensible, I think. I think there is room for more finesse in how the tests are defined and the reporting is done. I will think on that more, but it appears to be working for now. Will keep running tests against it and fill in docstrings.

I decided to ignore trying to implement fixes to other issues/bugs and focus on getting this working as-is.