### PR TITLE
Add certificate expiration comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+saml_reader/__pycache__/*
+saml_reader.egg-info/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-saml_reader/__pycache__/*
+saml_reader/**/__pycache__/*
 saml_reader.egg-info/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 saml_reader/**/__pycache__/*
 saml_reader.egg-info/*
+.vscode

--- a/README.md
+++ b/README.md
@@ -6,10 +6,39 @@ Please **DO NOT** add any personally identifiable information (PII) when reporti
 This means **DO NOT** upload any SAML data, even if it is yours. I don't want to be responsible
 for it. :)
 
+## Table of Contents
+
+- [SAML Reader](#saml-reader)
+  - [**IMPORTANT**](#important)
+  - [Table of Contents](#table-of-contents)
+  - [What is this tool?](#what-is-this-tool)
+  - [Installation](#installation)
+    - [Dependencies for `xmlsec`](#dependencies-for-xmlsec)
+    - [Installing from PyPI](#installing-from-pypi)
+    - [Installing from GitHub source](#installing-from-github-source)
+  - [Updating the package](#updating-the-package)
+    - [From PyPI](#from-pypi)
+    - [From GitHub source](#from-github-source)
+  - [Running the CLI](#running-the-cli)
+    - [Data Sources](#data-sources)
+      - [**Reading from a file**](#reading-from-a-file)
+      - [**Reading from clipboard**](#reading-from-clipboard)
+      - [**Reading from pipe**](#reading-from-pipe)
+    - [Other command line options](#other-command-line-options)
+      - [`--summary`](#--summary)
+      - [`--summary-only`](#--summary-only)
+      - [`--compare`](#--compare)
+  - [Reporting issues](#reporting-issues)
+  - [Contributing](#contributing)
+
 ## What is this tool?
 This tool parses SAML responses, gathering relevant info for diagnosing issues with federated authentication for MongoDB Cloud.
 
-### Installation
+---
+
+## Installation
+
+### Dependencies for `xmlsec`
 
 One of the tools used in this package requires `xmlsec`, which requires some libraries be installed on your system. See [this page](https://pypi.org/project/xmlsec/) for details on the required packages. For Mac, they can be installed by running [Homebrew](https://brew.sh/):
 
@@ -17,7 +46,11 @@ One of the tools used in this package requires `xmlsec`, which requires some lib
 brew install libxml2 libxmlsec1 pkg-config
 ```
 
-To install the actual package once the dependencies have been installed:
+For Windows, installing the `xmlsec` package from PyPI already has these dependencies pre-built into the installation process for the package, so there should be no need to install them separately.
+
+### Installing from PyPI
+
+To install SAML Reader from PyPI:
 
 1. If you wish to run this package in an environment such as [virtualenv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) or [Anaconda](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html), create the environment of your choice with Python 3.6+ and activate it. I always recommend installing in an environment, but if you wish to install the package globally, skip to step 2.
 2. Install the package from PyPI:
@@ -26,11 +59,22 @@ pip install saml_reader
 ```
 3. Run the command line interface by running `saml_reader` with options specified below.
 
-This tool requires a few external packages for parsing the data and running tests.
+### Installing from GitHub source
 
-### Updating the package
+If you wish to install from the GitHub source:
 
-As this software is in its infancy, updates will be made quickly as bugs are discovered and improvements are made. To get the latest version, run:
+1. Clone the repository locally with `git clone`.
+2. Ideally, create an environment such as [virtualenv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) or [Anaconda](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html), create the environment of your choice with Python 3.6+ and activate it.
+3. In the root directory of the repository, run `pip install .` to install the package. If you are planning to make changes to the package, run `pip install -e .` instead to install the package in editable mode.
+4. Run the command line interface by running `saml_reader` with options specified below.
+
+## Updating the package
+
+As this software is in its infancy, updates will be made quickly as bugs are discovered and improvements are made.
+
+### From PyPI
+
+To get the latest version, run:
 
 ```
 pip install --upgrade saml_reader
@@ -38,15 +82,30 @@ pip install --upgrade saml_reader
 
 This should uninstall the old version and install the new.
 
-### Running the CLI
+### From GitHub source
+
+To pull down the latest version:
+
+1. Checkout `master` branch with `git checkout master`.
+2. Run `git pull` to pull down the latest changes.
+3. If you installed in editable mode, you should be good to go. If you did not install in editable mode, run `pip install .` in the root directory of the repository.
+
+---
+
+## Running the CLI
 
 This tool can accept a SAML response as properly-formatted XML or
 a base64-encoded string, or it can be extracted directly from a HAR file dump. 
 The data can be input from a file, from the system clipboard,
 or from a Unix pipe.
 
-## Data Sources
-#### Reading from a file with different types
+### Data Sources
+
+You can read from a number of different sources in a number of different formats.
+
+#### **Reading from a file**
+
+You with different types
 
 ```bash
 saml_reader /path/to/file.xml   # XML is default type
@@ -54,7 +113,7 @@ saml_reader /path/to/base64.txt --type base64   # base64 requires flag
 saml_reader /path/to/harfile.har --type har     # har requires flag
 ```
 
-#### Reading from clipboard
+#### **Reading from clipboard**
 
 If you have the xml, base64, or har data in your system clipboard, run:
 
@@ -64,7 +123,7 @@ saml_reader --clip --type <xml, base64, har>
 
 The `--type` flag is not required for an XML file.
 
-#### Reading from pipe
+#### **Reading from pipe**
 
 If you prefer piping or have been doing your own parsing on the command line:
 
@@ -76,23 +135,23 @@ cat file.har | saml_reader --type har
 
 You can specify `saml_reader --stdin` but it is not required. 
 
-## Other command line options
+### Other command line options
 
 By default, the application will only output the results of validation
 tests. There are some extra options to expand the tests and the information
 that is output by the program.
 
-### `--summary`
+#### `--summary`
 
 This flag will print a full summary of key parameters pulled directly from the SAML 
 response and certificate.
 
-### `--summary-only`
+#### `--summary-only`
 
 This will only print the summary and skip any validation tests. Cannot be specified
 with `--compare`
 
-### `--compare`
+#### `--compare`
 
 This will allow the user to input expected values to compare with the SAML response.
 SAML Reader will prompt for each value in the terminal. Values can
@@ -110,6 +169,7 @@ Domain(s) associated with IdP:
 3. mydomain.com
 4. 
 IdP Issuer URI: Issuer_URI_Here
+Signing Certificate Expiration Date (MM/DD/YYYY): 01/31/2021
 Encryption Algorithm (SHA1 or SHA256): SHA256
 Is customer expecting role mapping (y/N): y
 Expected role mapping group names (if unknown, leave blank):
@@ -128,6 +188,7 @@ comparison values in the format:
   "lastName": "Ell",
   "email": "sam.ell@mydomain.com",
   "issuer": "Issuer URI here",
+  "cert_expiration": "Date in MM/DD/YYYY format",
   "acs": "Assertion Consumer Service URL here",
   "audience": "Audience URL here",
   "encryption": "Must be 'SHA1' or 'SHA256'",
@@ -139,6 +200,8 @@ comparison values in the format:
 
 Note that `domains` and `memberOf` must be lists. Any value can be omitted or substituted with `null` to be ignored. 
 An empty string (`""`) or empty list (`[]`) will be interpreted as an invalid value.
+
+---
 
 ## Reporting issues
 

--- a/saml_reader/cert.py
+++ b/saml_reader/cert.py
@@ -67,3 +67,6 @@ class Certificate(object):
             (basestring) subject common name
         """
         return self.get_subject().get("CN")
+
+    def get_expiration_date(self):
+        return self._certificate.not_valid_after.date()

--- a/saml_reader/cert.py
+++ b/saml_reader/cert.py
@@ -69,4 +69,10 @@ class Certificate(object):
         return self.get_subject().get("CN")
 
     def get_expiration_date(self):
+        """
+        Get expiration date for certificate
+
+        Returns:
+            datetime.date: the expiration date for the certificate
+        """
         return self._certificate.not_valid_after.date()

--- a/saml_reader/cli.py
+++ b/saml_reader/cli.py
@@ -117,10 +117,14 @@ def cli(cl_args):
             federation_config = prompt_for_comparison_values()
         else:
             print("Parsing comparison values...")
-            federation_config = parse_comparison_values_from_json(
-                parsed_args.compare[0])
-            if not federation_config:
-                return
+            try:
+                federation_config = parse_comparison_values_from_json(
+                    parsed_args.compare[0])
+            except ValueError as e:
+                if len(e.args) > 1:
+                    print(f"Attribute '{e.args[1]}' in the provided JSON did not pass validation")
+                    return
+                raise e
             print("Done")
 
     print("------------")
@@ -281,11 +285,7 @@ def parse_comparison_values_from_json(filename):
     """
     with open(filename, 'r') as f:
         comparison_values = json.load(f)
-    try:
-        federation_config = MongoFederationConfig(**comparison_values)
-    except ValueError as e:
-        print(f"Attribute '{e.args[1]}' in the provided JSON did not pass validation")
-        return None
+    federation_config = MongoFederationConfig(**comparison_values)
     return federation_config
 
 

--- a/saml_reader/cli.py
+++ b/saml_reader/cli.py
@@ -122,6 +122,7 @@ def cli(cl_args):
                     parsed_args.compare[0])
             except ValueError as e:
                 if len(e.args) > 1:
+                    # TODO: This could probably use a custom exception
                     print(f"Attribute '{e.args[1]}' in the provided JSON did not pass validation")
                     return
                 raise e

--- a/saml_reader/cli.py
+++ b/saml_reader/cli.py
@@ -1,10 +1,9 @@
 """
-Command line interface for SAML Reader parser. These functions handle all
-user interaction/display.
+Command line interface for SAML Reader parser. These functions handle display.
+User inputs are handled elsewhere.
 """
 import sys
 import json
-
 import argparse
 
 from saml_reader.text_reader import TextReader
@@ -28,7 +27,7 @@ def cli(cl_args):
                 to be read in. Must be one of: 'xml', 'base64', 'har'
             - `--compare <file, optional>`: optional argument. Compare SAML data vs. data entered
                 by user. If no file is specified, application will prompt for values. If file
-                specified, must be JSON file which matches the attribute keys in
+                specified, must be JSON file which contains only attribute keys found in
                 `UserInputValidation`
             - `--summary`: optional argument. Will output a summary of relevant
                 data read from SAML response.
@@ -275,7 +274,7 @@ def parse_comparison_values_from_json(filename):
 
     Args:
         filename (basestring): path to JSON-formatted file with comparison values
-            See `saml_reader.mongo.VALIDATION_REGEX_BY_ATTRIB` for valid fields.
+            See `UserInputValidation` for valid fields.
 
     Returns:
         (MongoFederationConfig) object containing validated comparison values

--- a/saml_reader/cli.py
+++ b/saml_reader/cli.py
@@ -177,6 +177,9 @@ def display_summary(validator):
               f"(from certificate):"
               f"\n{validator.get_identity_provider()}")
         print("---")
+        print(f"SIGNING CERTIFICATE EXPIRATION DATE (MM/DD/YYYY):"
+              f"\n{validator.get_certificate().get_expiration_date():%m/%d/%Y}")
+        print("---")
     print(f"ASSERTION CONSUMER SERVICE URL:"
           f"\n{validator.get_assertion_consumer_service_url() or '(this value is missing)'}")
     print("---")

--- a/saml_reader/validation/input_validation.py
+++ b/saml_reader/validation/input_validation.py
@@ -75,7 +75,8 @@ class UserInputParser:
             'firstName': lambda x: x.strip(),
             'lastName': lambda x: x.strip(),
             'email': lambda x: x.strip(),
-            'role_mapping_expected': lambda x: x.upper() == 'Y'
+            'role_mapping_expected': lambda x: x.upper() == 'Y',
+            'cert_expiration': lambda x: datetime.strptime(x, '%m/%d/%Y')
         }
 
     def parse(self, attribute_name, value):

--- a/saml_reader/validation/input_validation.py
+++ b/saml_reader/validation/input_validation.py
@@ -1,0 +1,266 @@
+import re
+
+"""Regular expression to match (most) valid e-mail addresses"""
+EMAIL_REGEX_MATCH = r"\b(?i)([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b"
+
+
+class _NullUserInput:
+    pass
+
+
+class UserInputValidator:
+    def __init__(self):
+        # Regular expressions to validate SAML fields and claim attributes
+        self._regex_by_attribute = {
+            'firstName': r'^\s*\S+.*$',
+            'lastName': r'^\s*\S+.*$',
+            'email': r"\b(?i)([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b",
+            'issuer': r'^\s*\S+.*$',
+            'acs': r'^https:\/\/auth\.mongodb\.com\/sso\/saml2\/[a-z0-9A-Z]{20}$',
+            'audience': r'^https:\/\/www\.okta\.com\/saml2\/service-provider\/[a-z]{20}$',
+            'encryption': r'^(?i)sha-?(1|256)$',
+            'domains': r'^(?i)[A-Z0-9.-]+?\.[A-Z]{2,}$',
+            'memberOf': r'^\s*\S+.*$',
+            'role_mapping_expected': '^(?i)[YN]$'
+        }
+
+        self._func_by_attribute = {
+            'cert_expiration': self._validate_cert_expiration
+        }
+
+    def __contains__(self, value):
+        return value in self._regex_by_attribute or value in self._func_by_attribute
+
+    def validate(self, attribute_name, value):
+        if value == _NullUserInput:
+            return True
+        
+        regex_valid = True
+        func_valid = True
+
+        if attribute_name in self._regex_by_attribute:
+            regex_valid = bool(re.fullmatch(self._regex_by_attribute[attribute_name], value))
+        if attribute_name in self._func_by_attribute:
+            func_valid = bool(self._func_by_attribute[attribute_name](value))
+
+        return regex_valid and func_valid
+
+    def get_validation_regex(self, attribute_name):
+        if attribute_name in self._regex_by_attribute:
+            return self._regex_by_attribute[attribute_name]
+        raise ValueError(f"Regex for attribute name '{attribute_name}' not found")
+
+    def _validate_cert_expiration(self, value):
+        return True
+
+
+class UserInputParser:
+    def __init__(self) -> None:
+        self._validator = UserInputValidator()
+
+        self._parsing_func_by_attribute = {
+            'domains': lambda x: [v.strip().lower() for v in x],
+            'encryption': lambda x: "SHA" + re.findall(
+                self._validator.get_validation_regex('encryption'), x)[0],
+            'firstName': lambda x: x.strip(),
+            'lastName': lambda x: x.strip(),
+            'email': lambda x: x.strip(),
+            'role_mapping_expected': lambda x: x.upper() == 'Y'
+        }
+
+    def parse(self, attribute_name, value):
+        if value == _NullUserInput or attribute_name not in self._parsing_func_by_attribute:
+            return value
+        return self._parsing_func_by_attribute[attribute_name](value)
+
+
+class MongoComparisonValue:
+    """
+    Collects comparison value input from the user through stdin prompts
+    """
+    def __init__(self, name, prompt, multi_value=False, default=_NullUserInput):
+        """
+        Create a comparison value object for a given value type.
+
+        Args:
+            name (basestring): name of the input value, must be contained in UserInputValidator.
+            prompt (basestring): the text with which to prompt the user during input
+            multi_value (bool, optional): True if the user should be prompted for more than one input value,
+                False will only prompt for one input value. Default: False (one input)
+            default (object, optional): The default value to set if the user does not input anything. Default: None
+        """
+        self._validator = UserInputValidator()
+        if name not in self._validator:
+            raise ValueError(f"Unknown value name: {name}")
+        self._name = name
+        self._prompt = prompt
+        self._value = _NullUserInput
+        self._is_multivalued = multi_value
+        if self._validator.validate(name, default):
+            self._default = default
+        else:
+            raise ValueError(f"Invalid default value '{default}' for attribute '{name}'")
+
+    def prompt_for_user_input(self):
+        """
+        Prompt user for input using stdin.
+
+        Returns:
+            (`basestring`, `list`, or `object`) The user input as a string or list, depending if multi-valued
+                or the default value if no user input provided
+        """
+        if self._is_multivalued:
+            user_input = self._get_multi_value()
+        else:
+            user_input = self._get_single_value()
+
+        if user_input is _NullUserInput:
+            self._value = self._default
+        
+        self._value = user_input
+
+    def get_name(self):
+        """
+        Get value name
+
+        Returns:
+            (basestring) value name
+        """
+        return self._name
+
+    def get_value(self):
+        if self._value is _NullUserInput:
+            raise ValueError("This value has not been gathered yet!")
+        return self._value
+
+    def set_value(self, value):
+        if isinstance(value, list):
+            value_list = value
+        else:
+            value_list = [value]
+        if all(self._validator.validate(self._name, v) for v in value_list):
+            self._value = value
+        else:
+            raise ValueError("Input did not pass validation")
+
+    def is_null(self):
+        return self._value is _NullUserInput
+
+    def _get_single_value(self):
+        """
+        Prompt user for a single value with default prompt.
+
+        Returns:
+            (`basestring` or `object`) The user input as a string
+                or the default value if no user input provided
+        """
+        return self._get_and_validate_user_input()
+
+    def _get_multi_value(self):
+        """
+        Prompt user for a multiple values with a numbered prompt.
+
+        Returns:
+            (`list` or `object`) The user input as a list
+                or the default value if no user input provided
+        """
+        input_to_store = []
+        print(self._prompt)
+        list_index = 1
+        user_input = self._get_and_validate_user_input(prompt=f"{list_index}.")
+        while user_input is not _NullUserInput:
+            input_to_store.append(user_input)
+            list_index += 1
+            user_input = self._get_and_validate_user_input(prompt=f"{list_index}.")
+        if not input_to_store:
+            input_to_store = self._default
+
+        return input_to_store
+
+    def _get_and_validate_user_input(self, prompt=None):
+        """
+        Prompts user for input from stdin.
+
+        Args:
+            prompt (basestring, optional): The text to prompt the user with.
+                Default: None (prompts with self._prompt)
+
+        Returns:
+            (`basestring`) the data input by the user. None if user inputs nothing.
+        """
+        if prompt is None:
+            prompt = self._prompt
+
+        if not re.match(r'.*\s$', prompt):
+            # If the prompt doesn't end with a whitespace character, add a space for padding
+            prompt += " "
+
+        while True:
+            user_input = input(prompt)
+            if user_input:
+                if self._validator.validate(self._name, user_input):
+                    return user_input
+                else:
+                    print(f"Input did not pass validation. Try again or skip the value.")
+            else:
+                return _NullUserInput
+
+
+class MongoFederationConfig:
+    """
+    Stores user-provided federation configuration values for comparison with SAML data
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Set comparison values and verify they match a regular expression (input validation)
+
+        Args:
+            **kwargs: currently accepted keywords are:
+                - `issuer`: Issuer URI
+                - `audience`: Audience URL
+                - `acs`: Assertion Consumer Service URL
+                - `encryption`: Encryption algorithm
+                - `firstName`: expected value for "firstName" claim attribute
+                - `lastName`: expected value for "lastName" claim attribute
+                - `email`: expected value for Name ID and "email" claim attribute
+                - `domains`: domain names associated with the identity provider, as a
+                    string. Multiple domains separated by whitespace.
+        """
+        self._settings = dict()
+        self._parser = UserInputParser()
+        if kwargs:
+            for name, value in kwargs.items():
+                value_obj = MongoComparisonValue(name, "")
+                try:
+                    value_obj.set_value(value)
+                except ValueError:
+                    raise ValueError(f"Input for attribute {name} did not pass validation", name)
+                self.set_value(value_obj)
+
+    def get_parsed_value(self, value_name, default=None):
+        """
+        Get comparison value by name
+
+        Args:
+            value_name (basestring): name of comparison value keyword
+            default (object, optional): the value returned if the comparison value is not populated. Default: None
+
+        Returns:
+            (`basestring` or `None`) comparison value, `None` if name does not exist
+        """
+        return self._settings.get(value_name, default)
+
+    def set_values(self, value_list):
+        if not all(isinstance(v, MongoComparisonValue) for v in value_list):
+            raise TypeError("All values must be of type MongoComparisonValue")
+
+        for value_obj in value_list:
+            name = value_obj.get_name()
+            value = value_obj.get_value()
+            self._settings[name] = self._parser.parse(name, value)
+
+    def set_value(self, value):
+        if not isinstance(value, MongoComparisonValue):
+            raise TypeError("Value must be of type MongoComparisonValue")
+        self.set_values([value])

--- a/saml_reader/validation/input_validation.py
+++ b/saml_reader/validation/input_validation.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 
 """Regular expression to match (most) valid e-mail addresses"""
 EMAIL_REGEX_MATCH = r"\b(?i)([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b"
@@ -51,6 +52,15 @@ class UserInputValidator:
         raise ValueError(f"Regex for attribute name '{attribute_name}' not found")
 
     def _validate_cert_expiration(self, value):
+        try:
+            # Make sure it's a correctly-formatted date
+            date = datetime.strptime(value, '%m/%d/%Y')
+        except ValueError as e:
+            if "does not match format" in e.args[0]: 
+                return False
+        if date < datetime.now():
+            # Date must be in the future
+            return False
         return True
 
 

--- a/saml_reader/validation/input_validation.py
+++ b/saml_reader/validation/input_validation.py
@@ -73,7 +73,7 @@ class UserInputParser:
             'lastName': lambda x: x.strip(),
             'email': lambda x: x.strip(),
             'role_mapping_expected': lambda x: x.upper() == 'Y',
-            'cert_expiration': lambda x: datetime.strptime(x, '%m/%d/%Y')
+            'cert_expiration': lambda x: datetime.strptime(x, '%m/%d/%Y').date()
         }
 
     def parse(self, attribute_name, value):

--- a/saml_reader/validation/input_validation.py
+++ b/saml_reader/validation/input_validation.py
@@ -1,9 +1,6 @@
 import re
 from datetime import datetime
 
-"""Regular expression to match (most) valid e-mail addresses"""
-EMAIL_REGEX_MATCH = r"\b(?i)([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b"
-
 
 class _NullUserInput:
     pass

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -1276,7 +1276,23 @@ class ValidationReport:
                 f"Specified comparison value: " +
                 f"{self._comparison_values.get_parsed_value('encryption')}" +
                 "\n\nGenerally, this means that the Atlas configuration needs " +
-                "to be set to match the SAML value"
+                "to be set to match the SAML value",
+
+            # Certificate tests
+            'certificate_not_expired': 
+                f"The SAML signing certificate included with the SAML response appears expired\n" +
+                f"or it expires today.\n" +
+                f"Expiration date (MM/DD/YYYY): {self._saml.get_certificate().get_expiration_date():%m/%d/%Y}\n" +
+                "\nGenerally, this means that the identity provider needs to be updated with a\n" +
+                "valid certificate pair, and that the public certificate of the pair must be re-uploaded to Atlas.",
+            'match_certificate_expiry':
+                f"The expiration of the SAML signing certificate included with the SAML response\n" +
+                f"does not match the specified expiration date.\n" +
+                f"SAML value (MM/DD/YYYY): {self._saml.get_certificate().get_expiration_date():%m/%d/%Y}\n" +
+                f"Specified comparison value: " +
+                f"{self._comparison_values.get_parsed_value('cert_expiration'):%m/%d/%Y}" +
+                "\n\nThis is a likely indicator that the SAML signing certiticate uploaded to Atlas is not the\n" +
+                "correct certificate. Please direct the customer to upload the correct public certificate.",
         }
 
         self._messages = messages

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -3,23 +3,7 @@ These classes handle all data validation specific to MongoDB Cloud
 """
 import re
 from saml_reader.validation.graph_suite import TestDefinition, TestSuite, TEST_FAIL
-
-"""Regular expression to match (most) valid e-mail addresses"""
-EMAIL_REGEX_MATCH = r"\b(?i)([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b"
-
-"""Regular expressions to validate SAML fields and claim attributes"""
-VALIDATION_REGEX_BY_ATTRIB = {
-    'firstName': r'^\s*\S+.*$',
-    'lastName': r'^\s*\S+.*$',
-    'email': EMAIL_REGEX_MATCH,
-    'issuer': r'^\s*\S+.*$',
-    'acs': r'^https:\/\/auth\.mongodb\.com\/sso\/saml2\/[a-z0-9A-Z]{20}$',
-    'audience': r'^https:\/\/www\.okta\.com\/saml2\/service-provider\/[a-z]{20}$',
-    'encryption': r'^(?i)sha-?(1|256)$',
-    'domains': r'^(?i)[A-Z0-9.-]+?\.[A-Z]{2,}$',
-    'memberOf': r'^\s*\S+.*$',
-    'role_mapping_expected': '^(?i)[YN]$'
-}
+from saml_reader.validation.input_validation import MongoFederationConfig, UserInputValidator
 
 
 class MongoSamlValidator:
@@ -209,230 +193,6 @@ class MongoSamlValidator:
             (`list` of `str`) Error messages generated
         """
         return self._errors
-
-
-class MongoFederationConfig:
-    """
-    Stores user-provided federation configuration values for comparison with SAML data
-    """
-
-    ATTRIB_PARSING_FUNCS = {
-        'domains': lambda x: [v.strip().lower() for v in x],
-        'encryption': lambda x: "SHA" + re.findall(VALIDATION_REGEX_BY_ATTRIB['encryption'], x[0])[0],
-        'firstName': lambda x: x[0].strip(),
-        'lastName': lambda x: x[0].strip(),
-        'email': lambda x: x[0].strip(),
-        'issuer': lambda x: x[0],
-        'acs': lambda x: x[0],
-        'audience': lambda x: x[0],
-        'role_mapping_expected': lambda x: x[0].upper() == 'Y'
-    }
-
-    def __init__(self, **kwargs):
-        """
-        Set comparison values and verify they match a regular expression (input validation)
-
-        Args:
-            **kwargs: currently accepted keywords are:
-                - `issuer`: Issuer URI
-                - `audience`: Audience URL
-                - `acs`: Assertion Consumer Service URL
-                - `encryption`: Encryption algorithm
-                - `firstName`: expected value for "firstName" claim attribute
-                - `lastName`: expected value for "lastName" claim attribute
-                - `email`: expected value for Name ID and "email" claim attribute
-                - `domains`: domain names associated with the identity provider, as a
-                    string. Multiple domains separated by whitespace.
-        """
-        self._settings = dict()
-        if kwargs:
-            self.set_values(kwargs)
-
-    def get_value(self, value_name, default=None):
-        """
-        Get comparison value by name
-
-        Args:
-            value_name (basestring): name of comparison value keyword
-            default (object, optional): the value returned if the comparison value is not populated. Default: None
-
-        Returns:
-            (`basestring` or `None`) comparison value, `None` if name does not exist
-        """
-        return self._settings.get(value_name, default)
-
-    def set_values(self, value_dict):
-        """
-        Set multiple comparison values
-
-        Args:
-            value_dict (dict): comparison values, keyed by keyword name
-
-        Returns:
-            None
-        """
-        for name, value in value_dict.items():
-            self.set_value(name, value)
-
-    def set_value(self, name, value):
-        """
-        Sets a single comparison value by name and value if it matches input validation.
-        See `MongoFederationConfig.__init__()` for the list of valid keywords.
-
-        Args:
-            name (basestring): a valid keyword
-            value (`basestring` or `list` of `basestring`): comparison value(s) for keyword
-
-        Returns:
-            None
-
-        Raises:
-            (ValueError) if value doesn't pass validation or keyword is not recognized
-        """
-        if value is None:
-            return
-
-        if name in VALIDATION_REGEX_BY_ATTRIB:
-            if not isinstance(value, list):
-                value = [value]
-            if all(self.validate_input(name, v) for v in value):
-                if name in self.ATTRIB_PARSING_FUNCS:
-                    # Check if we need to parse the value
-                    value = self.ATTRIB_PARSING_FUNCS[name](value)
-                self._settings[name] = value
-            else:
-                raise ValueError(f"Attribute '{name}' did not pass input validation")
-        else:
-            raise ValueError(f"Unknown attribute name: {name}")
-
-    @staticmethod
-    def validate_input(name, value):
-        """
-        Validates input for a certain attribute against expected regex pattern
-
-        Args:
-            name (basestring): name of the attribute
-            value (basestring): value to validate
-
-        Returns:
-            (bool) True if matches, false otherwise
-        """
-        if name not in VALIDATION_REGEX_BY_ATTRIB:
-            raise ValueError(f"Unknown attribute name: {name}")
-        if value is None:
-            return True
-        return bool(re.fullmatch(VALIDATION_REGEX_BY_ATTRIB[name], value))
-
-
-class MongoComparisonValue:
-    """
-    Collects comparison value input from the user through stdin prompts
-    """
-    def __init__(self, name, prompt, multi_value=False, default=None):
-        """
-        Create a comparison value object for a given value type.
-
-        Args:
-            name (basestring): name of the input value, must be contained in VALIDATION_REGEX_BY_ATTRIB.
-            prompt (basestring): the text with which to prompt the user during input
-            multi_value (bool, optional): True if the user should be prompted for more than one input value,
-                False will only prompt for one input value. Default: False (one input)
-            default (object, optional): The default value to set if the user does not input anything. Default: None
-        """
-        if name not in VALIDATION_REGEX_BY_ATTRIB:
-            raise ValueError(f"Unknown value name: {name}")
-        self._name = name
-        self._prompt = prompt
-        self._multi_value = multi_value
-        if MongoFederationConfig.validate_input(name, default):
-            self._default = default
-        else:
-            raise ValueError(f"Invalid default value '{default}' for attribute '{name}'")
-
-    def prompt_for_user_input(self):
-        """
-        Prompt user for input using stdin.
-
-        Returns:
-            (`basestring`, `list`, or `object`) The user input as a string or list, depending if multi-valued
-                or the default value if no user input provided
-        """
-        if self._multi_value:
-            user_input = self._get_multi_value()
-        else:
-            user_input = self._get_single_value()
-
-        if user_input is None:
-            return self._default
-        return user_input
-
-    def get_name(self):
-        """
-        Get value name
-
-        Returns:
-            (basestring) value name
-        """
-        return self._name
-
-    def _get_single_value(self):
-        """
-        Prompt user for a single value with default prompt.
-
-        Returns:
-            (`basestring` or `object`) The user input as a string
-                or the default value if no user input provided
-        """
-        return self._get_and_validate_user_input()
-
-    def _get_multi_value(self):
-        """
-        Prompt user for a multiple values with a numbered prompt.
-
-        Returns:
-            (`list` or `object`) The user input as a list
-                or the default value if no user input provided
-        """
-        input_to_store = []
-        print(self._prompt)
-        list_index = 1
-        user_input = self._get_and_validate_user_input(prompt=f"{list_index}.")
-        while user_input:
-            input_to_store.append(user_input)
-            list_index += 1
-            user_input = self._get_and_validate_user_input(prompt=f"{list_index}.")
-        if not input_to_store:
-            input_to_store = self._default
-
-        return input_to_store
-
-    def _get_and_validate_user_input(self, prompt=None):
-        """
-        Prompts user for input from stdin.
-
-        Args:
-            prompt (basestring, optional): The text to prompt the user with.
-                Default: None (prompts with self._prompt)
-
-        Returns:
-            (`basestring`) the data input by the user. None if user inputs nothing.
-        """
-        if prompt is None:
-            prompt = self._prompt
-
-        if not re.match(r'.*\s$', prompt):
-            # If the prompt doesn't end with a whitespace character, add a space for padding
-            prompt += " "
-
-        while True:
-            user_input = input(prompt)
-            if user_input:
-                if MongoFederationConfig.validate_input(self._name, user_input):
-                    return user_input
-                else:
-                    print(f"Input did not pass validation. Try again or skip the value.")
-            else:
-                return None
 
 
 class MongoTestSuite(TestSuite):
@@ -684,7 +444,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if a comparison value exists, False otherwise
         """
-        return context.get('comparison_values').get_value('issuer') is not None
+        return context.get('comparison_values').get_parsed_value('issuer') is not None
 
     @staticmethod
     def verify_issuer(context):
@@ -697,7 +457,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if they match, False otherwise
         """
-        return context.get('saml').get_issuer_uri() == context.get('comparison_values').get_value('issuer')
+        return context.get('saml').get_issuer_uri() == context.get('comparison_values').get_parsed_value('issuer')
 
     @staticmethod
     def verify_issuer_pattern(context):
@@ -710,7 +470,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if matches the regex, False otherwise
         """
-        return MongoTestSuite._matches_regex(VALIDATION_REGEX_BY_ATTRIB['issuer'],
+        return MongoTestSuite._matches_regex(UserInputValidator().get_validation_regex('issuer'),
                                              context.get('saml').get_issuer_uri())
 
     # Audience URL tests
@@ -738,7 +498,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if a comparison value exists, False otherwise
         """
-        return context.get('comparison_values').get_value('audience') is not None
+        return context.get('comparison_values').get_parsed_value('audience') is not None
 
     @staticmethod
     def verify_audience_url(context):
@@ -752,7 +512,7 @@ class MongoTestSuite(TestSuite):
             (bool) True if they match, False otherwise
         """
         return context.get('saml').get_audience_url() == \
-               context.get('comparison_values').get_value('audience')
+               context.get('comparison_values').get_parsed_value('audience')
 
     @staticmethod
     def verify_audience_url_pattern(context):
@@ -765,7 +525,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if matches the regex, False otherwise
         """
-        return MongoTestSuite._matches_regex(VALIDATION_REGEX_BY_ATTRIB['audience'],
+        return MongoTestSuite._matches_regex(UserInputValidator().get_validation_regex('audience'),
                                              context.get('saml').get_audience_url())
 
     # Assertion Consumer Service URL tests
@@ -793,7 +553,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if a comparison value exists, False otherwise
         """
-        return context.get('comparison_values').get_value('acs') is not None
+        return context.get('comparison_values').get_parsed_value('acs') is not None
 
     @staticmethod
     def verify_assertion_consumer_service_url(context):
@@ -807,7 +567,7 @@ class MongoTestSuite(TestSuite):
             (bool) True if they match, False otherwise
         """
         return context.get('saml').get_assertion_consumer_service_url() == \
-               context.get('comparison_values').get_value('acs')
+               context.get('comparison_values').get_parsed_value('acs')
 
     @staticmethod
     def verify_assertion_consumer_service_url_pattern(context):
@@ -820,7 +580,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if matches the regex, False otherwise
         """
-        return MongoTestSuite._matches_regex(VALIDATION_REGEX_BY_ATTRIB['acs'],
+        return MongoTestSuite._matches_regex(UserInputValidator().get_validation_regex('acs'),
                                              context.get('saml').get_assertion_consumer_service_url())
 
     # Encryption algorithm tests
@@ -848,7 +608,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if a comparison value exists, False otherwise
         """
-        return context.get('comparison_values').get_value('encryption') is not None
+        return context.get('comparison_values').get_parsed_value('encryption') is not None
 
     @staticmethod
     def verify_encryption_algorithm(context):
@@ -864,7 +624,7 @@ class MongoTestSuite(TestSuite):
 
         # expected encryption algorithm format expected to be "SHA1" or "SHA256"
         return context.get('saml').get_encryption_algorithm() == \
-               context.get('comparison_values').get_value('encryption')
+               context.get('comparison_values').get_parsed_value('encryption')
 
     @staticmethod
     def verify_encryption_algorithm_pattern(context):
@@ -877,7 +637,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if matches the regex, False otherwise
         """
-        return MongoTestSuite._matches_regex(VALIDATION_REGEX_BY_ATTRIB['encryption'],
+        return MongoTestSuite._matches_regex(UserInputValidator().get_validation_regex('encryption'),
                                              context.get('saml').get_encryption_algorithm())
 
     # Name ID and format tests
@@ -893,7 +653,7 @@ class MongoTestSuite(TestSuite):
             (bool) True if they match, False otherwise
         """
         return context.get('saml').get_subject_name_id().lower() == \
-               context.get('comparison_values').get_value('email').lower()
+               context.get('comparison_values').get_parsed_value('email').lower()
 
     @staticmethod
     def verify_name_id_exists(context):
@@ -919,7 +679,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if matches the regex, False otherwise
         """
-        return MongoTestSuite._matches_regex(EMAIL_REGEX_MATCH,
+        return MongoTestSuite._matches_regex(UserInputValidator().get_validation_regex('email'),
                                              context.get('saml').get_subject_name_id())
 
     @staticmethod
@@ -974,7 +734,7 @@ class MongoTestSuite(TestSuite):
             (bool) true if matches, false otherwise
         """
         return MongoTestSuite._matches_regex(
-            VALIDATION_REGEX_BY_ATTRIB['firstName'],
+            UserInputValidator().get_validation_regex('firstName'),
             context.get('saml').get_attributes().get('firstName')
         )
 
@@ -986,7 +746,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if comparison value exists, false otherwise
         """
-        return context.get('comparison_values').get_value('firstName') is not None
+        return context.get('comparison_values').get_parsed_value('firstName') is not None
 
     @staticmethod
     def verify_first_name(context):
@@ -996,7 +756,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if matches, false otherwise
         """
-        return context.get('comparison_values').get_value('firstName').lower() == \
+        return context.get('comparison_values').get_parsed_value('firstName').lower() == \
                context.get('saml').get_attributes().get('firstName').lower()
 
     @staticmethod
@@ -1018,7 +778,7 @@ class MongoTestSuite(TestSuite):
             (bool) true if matches, false otherwise
         """
         return MongoTestSuite._matches_regex(
-            VALIDATION_REGEX_BY_ATTRIB['lastName'],
+            UserInputValidator().get_validation_regex('lastName'),
             context.get('saml').get_attributes().get('lastName')
         )
 
@@ -1030,7 +790,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if comparison value exists, false otherwise
         """
-        return context.get('comparison_values').get_value('lastName') is not None
+        return context.get('comparison_values').get_parsed_value('lastName') is not None
 
     @staticmethod
     def verify_last_name(context):
@@ -1040,7 +800,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if matches, false otherwise
         """
-        return context.get('comparison_values').get_value('lastName').lower() == \
+        return context.get('comparison_values').get_parsed_value('lastName').lower() == \
                context.get('saml').get_attributes().get('lastName').lower()
 
     @staticmethod
@@ -1062,7 +822,7 @@ class MongoTestSuite(TestSuite):
             (bool) true if matches, false otherwise
         """
         return MongoTestSuite._matches_regex(
-            VALIDATION_REGEX_BY_ATTRIB['email'],
+            UserInputValidator().get_validation_regex('email'),
             context.get('saml').get_attributes().get('email')
         )
 
@@ -1074,7 +834,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if comparison value exists, false otherwise
         """
-        return context.get('comparison_values').get_value('email') is not None
+        return context.get('comparison_values').get_parsed_value('email') is not None
 
     @staticmethod
     def verify_email(context):
@@ -1084,7 +844,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if matches, false otherwise
         """
-        return context.get('comparison_values').get_value('email').lower() == \
+        return context.get('comparison_values').get_parsed_value('email').lower() == \
                context.get('saml').get_attributes().get('email').lower()
 
     @staticmethod
@@ -1117,7 +877,7 @@ class MongoTestSuite(TestSuite):
         """
         return all(
             MongoTestSuite._matches_regex(
-                VALIDATION_REGEX_BY_ATTRIB['memberOf'], value
+                UserInputValidator().get_validation_regex('memberOf'), value
             ) for value in context.get('saml').get_attributes().get('memberOf', [])
         )
 
@@ -1130,7 +890,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if attribute exists and customer expects it, false otherwise
         """
-        return not context.get('comparison_values').get_value('role_mapping_expected', False)
+        return not context.get('comparison_values').get_parsed_value('role_mapping_expected', False)
 
     @staticmethod
     def verify_member_of_comparison_exists(context):
@@ -1140,7 +900,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) true if comparison value exists, false otherwise
         """
-        return context.get('comparison_values').get_value('memberOf') is not None
+        return context.get('comparison_values').get_parsed_value('memberOf') is not None
 
     @staticmethod
     def verify_member_of(context):
@@ -1153,7 +913,7 @@ class MongoTestSuite(TestSuite):
         member_of_groups = context.get('saml').get_attributes().get('memberOf', [])
         return all(
             group in member_of_groups
-            for group in context.get('comparison_values').get_value('memberOf', [])
+            for group in context.get('comparison_values').get_parsed_value('memberOf', [])
         )
 
     # Name ID, email, and domain tests
@@ -1181,7 +941,7 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if a comparison exists, False otherwise
         """
-        return context.get('comparison_values').get_value('domains') is not None
+        return context.get('comparison_values').get_parsed_value('domains') is not None
 
     @staticmethod
     def verify_domain_in_name_id(context):
@@ -1192,7 +952,7 @@ class MongoTestSuite(TestSuite):
             (bool) True if Name ID ends with one of the domains, False otherwise
         """
         return any(context.get('saml').get_subject_name_id().lower().endswith('@' + domain)
-                   for domain in context.get('comparison_values').get_value('domains'))
+                   for domain in context.get('comparison_values').get_parsed_value('domains'))
 
     @staticmethod
     def verify_domain_in_email(context):
@@ -1203,7 +963,7 @@ class MongoTestSuite(TestSuite):
             (bool) True if email contains ends with one of the domains, False otherwise
         """
         return any(context.get('saml').get_attributes().get('email').lower().endswith('@' + domain)
-                   for domain in context.get('comparison_values').get_value('domains'))
+                   for domain in context.get('comparison_values').get_parsed_value('domains'))
 
     @staticmethod
     def verify_domain_in_comparison_email(context):
@@ -1214,8 +974,8 @@ class MongoTestSuite(TestSuite):
         Returns:
             (bool) True if email contains ends with one of the domains, False otherwise
         """
-        return any(context.get('comparison_values').get_value('email').lower().endswith('@' + domain)
-                   for domain in context.get('comparison_values').get_value('domains'))
+        return any(context.get('comparison_values').get_parsed_value('email').lower().endswith('@' + domain)
+                   for domain in context.get('comparison_values').get_parsed_value('domains'))
 
 
 class ValidationReport:
@@ -1274,7 +1034,7 @@ class ValidationReport:
         return f"The required '{attribute_name}' claim attribute does not match " + \
                "the value entered for comparison." + \
                f"\nSAML value: {self._saml.get_attributes().get(attribute_name)}" + \
-               f"\nSpecified comparison value: {self._comparison_values.get_value(attribute_name)}" + \
+               f"\nSpecified comparison value: {self._comparison_values.get_parsed_value(attribute_name)}" + \
                "\n\nGenerally, this means that the identity provider configuration needs\n" + \
                "to be reconfigured to match the expected values"
 
@@ -1354,7 +1114,7 @@ class ValidationReport:
                 f"The optional 'memberOf' claim attribute is missing one or more values entered for comparison." + \
                 f"\nSAML value:" + self._print_a_list("\n - {}", self._saml.get_attributes().get('memberOf', [])) + \
                 f"\nSpecified comparison value:" + self._print_a_list(
-                    "\n - {}", self._comparison_values.get_value('memberOf', [])) + \
+                    "\n - {}", self._comparison_values.get_parsed_value('memberOf', [])) + \
                 "\n\nGenerally, this means that the user's account in the customer Active Directory\n" + \
                 "needs to be added to the correct group.",
 
@@ -1363,7 +1123,7 @@ class ValidationReport:
                 "The 'email' attribute does not contain one of the federated domains specified:\n" +
                 f"SAML 'email' attribute value: {self._saml.get_subject_name_id()}\n" +
                 f"Specified valid domains:" +
-                self._print_a_list("\n - {}", self._comparison_values.get_value('domains', [])) +
+                self._print_a_list("\n - {}", self._comparison_values.get_parsed_value('domains', [])) +
                 "\n\nIf the 'email' attribute does not contain a verified domain name, it may be because\n" +
                 "the source Active Directory field does not contain the user's e-mail address.\n" +
                 "The source field may contain an internal username or other value instead.\n" +
@@ -1374,16 +1134,16 @@ class ValidationReport:
             'compare_domain_comparison_email':
                 "The specified comparison e-mail value does not contain\n" +
                 "one of the federated domains specified:\n" +
-                f"Specified e-mail value: {self._comparison_values.get_value('email')}\n" +
+                f"Specified e-mail value: {self._comparison_values.get_parsed_value('email')}\n" +
                 f"Specified valid domains:" +
-                self._print_a_list("\n - {}", self._comparison_values.get_value('domains', [])) +
+                self._print_a_list("\n - {}", self._comparison_values.get_parsed_value('domains', [])) +
                 "\n\nIf the e-mail specified is the user's MongoDB username, then the Atlas\n" +
                 "identity provider configuration likely has the incorrect domain(s) verified.",
             'compare_domain_name_id':
                 "The Name ID does not contain one of the federated domains specified:\n" +
                 f"Name ID value: {self._saml.get_subject_name_id()}\n" +
                 f"Specified valid domains:" +
-                self._print_a_list("\n - {}", self._comparison_values.get_value('domains', [])) +
+                self._print_a_list("\n - {}", self._comparison_values.get_parsed_value('domains', [])) +
                 "\n\nIf the Name ID does not contain a verified domain name, it may be because\n" +
                 "the source Active Directory field does not contain the user's e-mail address.\n" +
                 "The source field may contain an internal username or other value instead.",
@@ -1392,7 +1152,7 @@ class ValidationReport:
             'compare_email_name_id':
                 "The Name ID does not match the provided e-mail value:\n" +
                 f"Name ID value: {self._saml.get_subject_name_id()}\n" +
-                f"Specified email value: {self._comparison_values.get_value('email')}" +
+                f"Specified email value: {self._comparison_values.get_parsed_value('email')}" +
                 "\n\nThis is not necessarily an error, but may indicate there is a misconfiguration.\n" +
                 "The value in Name ID will be the user's login username and the value in the\n" +
                 "email attribute will be the address where the user receives email messages.",
@@ -1412,7 +1172,7 @@ class ValidationReport:
             'match_issuer':
                 "The Issuer URI in the SAML response does not match the specified comparison value:\n" +
                 f"SAML value: {self._saml.get_issuer_uri()}\n" +
-                f"Specified comparison value: {self._comparison_values.get_value('issuer')}" +
+                f"Specified comparison value: {self._comparison_values.get_parsed_value('issuer')}" +
                 "\n\nGenerally, this means that the Atlas configuration needs " +
                 "to be set to match the SAML value",
 
@@ -1426,7 +1186,7 @@ class ValidationReport:
             'match_audience':
                 "The Audience URL in the SAML response does not match the specified comparison value:\n" +
                 f"SAML value: {self._saml.get_audience_url()}\n" +
-                f"Specified comparison value: {self._comparison_values.get_value('audience')}" +
+                f"Specified comparison value: {self._comparison_values.get_parsed_value('audience')}" +
                 "\n\nGenerally, this means that the Atlas configuration needs " +
                 "to be set to match the SAML value",
 
@@ -1441,7 +1201,7 @@ class ValidationReport:
                 "The Assertion Consumer Service URL in the SAML response does not match the " +
                 "specified comparison value:\n" +
                 f"SAML value: {self._saml.get_assertion_consumer_service_url()}\n" +
-                f"Specified comparison value: {self._comparison_values.get_value('acs')}" +
+                f"Specified comparison value: {self._comparison_values.get_parsed_value('acs')}" +
                 "\n\nThis means that the identity provider configuration needs\n" +
                 "to be reconfigured to match the expected value",
 
@@ -1457,7 +1217,7 @@ class ValidationReport:
                 "match the specified comparison value:\n" +
                 f"SAML value: {self._saml.get_encryption_algorithm()}\n" +
                 f"Specified comparison value: " +
-                f"{self._comparison_values.get_value('encryption')}" +
+                f"{self._comparison_values.get_parsed_value('encryption')}" +
                 "\n\nGenerally, this means that the Atlas configuration needs " +
                 "to be set to match the SAML value"
         }

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -22,7 +22,7 @@ VALIDATION_REGEX_BY_ATTRIB = {
 }
 
 
-class MongoVerifier:
+class MongoSamlValidator:
     """
     Interprets SAML and certificate data and compares it against expected patterns specific
     to MongoDB Cloud and entered values
@@ -281,7 +281,7 @@ class MongoFederationConfig:
 
         Args:
             name (basestring): a valid keyword
-            value (basestring): comparison value for keyword
+            value (`basestring` or `list` of `basestring`): comparison value(s) for keyword
 
         Returns:
             None

--- a/saml_reader/validation/mongo.py
+++ b/saml_reader/validation/mongo.py
@@ -1,5 +1,5 @@
 """
-These classes handle all data validation specific to MongoDB Cloud
+These classes handle SAML data validation specific to MongoDB Cloud
 """
 import re
 from datetime import datetime
@@ -11,7 +11,7 @@ from saml_reader.validation.input_validation import MongoFederationConfig, UserI
 class MongoSamlValidator:
     """
     Interprets SAML and certificate data and compares it against expected patterns specific
-    to MongoDB Cloud and entered values
+    to MongoDB Cloud and entered comparison values
     """
 
     def __init__(self, saml, cert=None, comparison_values=None):
@@ -121,7 +121,7 @@ class MongoSamlValidator:
         Get SAML signing certificate.
 
         Returns:
-            (`saml_reader.cert.Certificate` or `None`) Certificate object, if valid one found in SAML, otherwise None
+            (`Certificate` or `None`) Certificate object, if valid one found in SAML, otherwise None
         """
         return self._cert
 
@@ -238,6 +238,8 @@ class MongoTestSuite(TestSuite):
 
         Args:
             saml (BaseSamlParser): parsed SAML data
+            certificate (Certificate, optional): SAML signing certificate, if one was
+                provided in the SAML data. Default: None (no certificate available)
             comparison_values (MongoFederationConfig, optional): comparison values to
                 compare with data in SAML response. Default: None (no comparison
                 tests will be performed)
@@ -1061,8 +1063,12 @@ class ValidationReport:
 
         Args:
             saml (BaseSamlParser): parsed SAML data
+            certificate (`Certificate` or `None`): SAML signing certificate
             comparison_values (MongoFederationConfig): comparison data
         """
+        # TODO: We should probably overhaul this class so that it doesn't require
+        #       valid data, meaning that it should skip building messages that depend
+        #       on having data that isn't available (like the certificate).
         self._saml = saml
         self._certificate = certificate
         self._comparison_values = comparison_values
@@ -1130,7 +1136,7 @@ class ValidationReport:
 
     def _compile_messages(self):
         """
-        Generates messages for failed tests based on provided SAML and comparison data.
+        Generates messages for failed tests based on provided SAML, certificate, and comparison data.
 
         Any future tests that require a report be generated should they fail should have
         an entry added to the `messages` dict with the test name as the key.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
       install_requires=[
             'pyperclip',
             'haralyzer',
-            'python3-saml',
+            'python3-saml==1.10.1',
             'cryptography',
             'networkx',
             'lxml',     # This should be installed as part of python3-saml


### PR DESCRIPTION
### Summary of added functionality

This implements the feature in #47 which checks the SAML signing certificate expiration date against a comparison value, which is visible from the Atlas console. This is a test for certificate validity in lieu of having the actual certificate to do a proper validation.

### Steps to complete

- [x] Refactor validation to allow for arbitrary function to validate instead of just regex
- [x] Add ability to input a comparison date in the CLI and by JSON
- [x] Write validation and parsing functions for date input
- [x] Add function to pull expiration date for cert read from SAML response
- [x] Add tests to `MongoTestSuite` to:
  - [x] Validate a certificate is present in the SAML data
  - [ ] ~Validate the date is readable~ (we should get this for free with the first test)
  - [x] Validate that the date is in the future (i.e. the cert is not expired)
  - [x] Compare the cert date with the comparison value
- [x] Add validation report info for the above tests
- [x] Add certificate date to the SAML summary information
- [x] Add and update docstrings
- [x] Update readme page with changes

### Implementation notes and additional changes

To do this, I had to do some refactoring not directly related to this feature:
- User input validation now all lives in `saml_reader.validation.input_validation`
- New classes `UserInputValidator` and `UserInputParser` do the heavy lifting to validate input and parse it for storage in `MongoFederationConfig`, respectively.
- In turn, `saml_reader.validation.mongo` includes `MongoFederationConfig` and the `MongoTestSuite` classes. All actual input validation was removed from `MongoFederationConfig`. However, to handle JSON input, which sends those values directly to the constructor of  `MongoFederationConfig`, the class does send those values through the `MongoComparisonValue` pipeline for validation.
- Empty user responses are now recorded as `_NullUserInput` instead of `None`
- Necessary adjustments to the CLI interface where user input is collected were made accordingly.

In large part, this was done to allow for both regex-type validation and/or the execution of an arbitrary validation function. This was needed to validate the entered date as a valid date, because this is not (easily) doable with regex. It future-proofs for any other inputs that we may want to validate with an arbitrary function.