### PR TITLE
Support python3-saml==1.14.0

### DIFF
--- a/saml_reader/saml/oli.py
+++ b/saml_reader/saml/oli.py
@@ -125,7 +125,7 @@ class OLISamlParser(OneLogin_Saml2_Response):
         Returns:
             (`list` of `lxml.etree.Element`) requested nodes
         """
-        return self._OneLogin_Saml2_Response__query_assertion(path)
+        return self._query_assertion(path)
 
     def query(self, path):
         """
@@ -137,7 +137,7 @@ class OLISamlParser(OneLogin_Saml2_Response):
         Returns:
             (`list` of `lxml.etree.Element`) requested nodes
         """
-        return self._OneLogin_Saml2_Response__query(path)
+        return self._query(path)
 
 
 class CustomXMLParser(OneLogin_Saml2_XML):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
       install_requires=[
             'pyperclip',
             'haralyzer',
-            'python3-saml==1.10.1',
+            'python3-saml==1.14.0',
             'cryptography',
             'networkx',
             'lxml',     # This should be installed as part of python3-saml


### PR DESCRIPTION
They made the query functions into private methods instead of dunder private methods. Fix #49 